### PR TITLE
Enables using wp-mvc actions as Widgets

### DIFF
--- a/core/mvc_dispatcher.php
+++ b/core/mvc_dispatcher.php
@@ -36,7 +36,27 @@ class MvcDispatcher {
                 $controller->{$method}();
             }
         }
-        $controller->{$action}();
+        
+        // If we can access the response from our controller's actions (methods)
+        // we can use them (the actions) as Widgets in the both sides - outside of wp-mvc plugin and inside of it.
+        // The action should return whatever you want, except $this->render_view('view_name').
+        // Example: Let's say we have 'UserController' and action 'list' and we want somewhere in Wordpress or another
+        // plugin to get all users and to reuse UserController list method, so:
+        // class UserController extends MvcPublicController {
+        //      public function list() {
+        //            $this->view_rendered = true;
+        //            $this->set_objects();
+        //            $response = this->render_to_string('users/list');
+        //            return $response;
+        //      }
+        // }
+        // and where we want to reuse it, we can get it in the following way:
+        // $widget = MvcDispatcher::dispatch(array(
+        // 			'controller' => 'users',
+        // 			'action'	 => 'list'
+        // ));
+        $response = $controller->{$action}();
+        
         if (!empty($controller->after)) {
             foreach ($controller->after as $method) {
                 $controller->{$method}();
@@ -47,6 +67,8 @@ class MvcDispatcher {
         if (!$controller->view_rendered) {
             $controller->render_view($controller->views_path.$action, $options);
         }
+        
+        return $response;
     
     }
     


### PR DESCRIPTION
If MvcDispatcher::dispatch() returns a value from controller's action (method), we can use our controller's actions as Widgets anywhere in the Wordpress.